### PR TITLE
Convert to sbol2

### DIFF
--- a/features_to_circuits/features_to_circuits.py
+++ b/features_to_circuits/features_to_circuits.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from Bio.Seq import Seq
-from sbol import *
+from sbol2 import *
 from flashtext import KeywordProcessor
 from sequences_to_features import Feature
 from sequences_to_features import FeatureLibrary

--- a/features_to_circuits/features_to_circuits.py
+++ b/features_to_circuits/features_to_circuits.py
@@ -185,6 +185,11 @@ class CircuitLibrary():
             return sink_doc.getComponentDefinition(mod_definition.identity)
         except RuntimeError:
             definition_copy = mod_definition.copy(sink_doc)
+        except SBOLError as exc:
+            if exc.error_code() == SBOLErrorCode.NOT_FOUND_ERROR:
+                definition_copy = mod_definition.copy(sink_doc)
+            else:
+                raise
 
         for sub_mod in mod_definition.modules:
             sub_mod_definition = source_doc.getModuleDefinition(sub_mod.definition)

--- a/sequences_to_features/sequences_to_features.py
+++ b/sequences_to_features/sequences_to_features.py
@@ -6,7 +6,7 @@ import requests
 import json
 
 from Bio.Seq import Seq
-from sbol import *
+from sbol2 import *
 from flashtext import KeywordProcessor
 
 # Set up the not found error for catching

--- a/sequences_to_features/sequences_to_features.py
+++ b/sequences_to_features/sequences_to_features.py
@@ -9,6 +9,15 @@ from Bio.Seq import Seq
 from sbol import *
 from flashtext import KeywordProcessor
 
+# Set up the not found error for catching
+try:
+    # SBOLError is in the native python module
+    NotFoundError = SBOLError
+except NameError:
+    # The swig wrapper raises RuntimeError on not found
+    NotFoundError = RuntimeError
+
+
 def load_sbol(sbol_file):
     logging.info('Loading %s', sbol_file)
 
@@ -237,9 +246,9 @@ class FeatureLibrary():
             else:
                 try:
                     sink_doc.getComponentDefinition(comp_definition.identity)
-                    
+
                     return None
-                except RuntimeError:
+                except NotFoundError:
                     definition_copy = comp_definition.copy(sink_doc)
 
             definition_copy.sequences = list(comp_definition.sequences)
@@ -280,7 +289,7 @@ class FeatureLibrary():
             for seq_URI in comp_definition.sequences:
                 try:
                     sink_doc.getSequence(seq_URI)
-                except RuntimeError:
+                except NotFoundError:
                     seq = source_doc.getSequence(seq_URI)
 
                     seq.copy(sink_doc)

--- a/sequences_to_features/sequences_to_features.py
+++ b/sequences_to_features/sequences_to_features.py
@@ -331,6 +331,11 @@ class FeatureAnnotater():
                 sub_comp = parent_definition.components.create('_'.join([child_definition.displayId, str(i)]))
             except RuntimeError:
                 sub_comp = None
+            except SBOLError as exc:
+                if exc.error_code() == SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE:
+                    sub_comp = None
+                else:
+                    raise
 
             if sub_comp is None:
                 i = i + 1
@@ -356,6 +361,11 @@ class FeatureAnnotater():
                                                                                   str(i)]))
             except RuntimeError:
                 seq_anno = None
+            except SBOLError as exc:
+                if exc.error_code() == SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE:
+                    seq_anno = None
+                else:
+                    raise
 
             if seq_anno is None:
                 i = i + 1

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'biopython>=1.7.4',
+    'dnaplotlib>=1.0',
     'flashtext>=2.7',
-    'pysbol>=2.3.1',
+    'sbol2',
     'matplotlib>=1.5.0'
 ]
 

--- a/test/test_curation.py
+++ b/test/test_curation.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from sbol import *
+from sbol2 import *
 
 from sequences_to_features import *
 from features_to_circuits import *


### PR DESCRIPTION
Change SYNBICT to use [pySBOL2](https://github.com/SynBioDex/pySBOL2).

This was primarily an update to exception handling to be compatible with both pySBOL and pySBOL2. Other than that it was updates to import statements and to setup.py as would be expected.

Fixes #48 
Fixes #46 
